### PR TITLE
Use ExpressionAttributeNames since partitionKey might be a reserved word

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,10 @@ FailClosed.prototype.acquireLock = function(id, callback)
                     owner: dataBag.owner,
                     guid: dataBag.guid
                 },
-                ConditionExpression: `attribute_not_exists(${self._partitionKey})`
+                ConditionExpression: 'attribute_not_exists(#PK)',
+                ExpressionAttributeNames: {
+                    '#PK': self._partitionKey
+                }
             };
             params.Item[self._partitionKey] = dataBag.id;
             self._dynamodb.put(params, (error, data) =>
@@ -210,7 +213,10 @@ FailOpen.prototype.acquireLock = function(id, callback)
                     owner: dataBag.owner,
                     guid: dataBag.guid
                 },
-                ConditionExpression: `attribute_not_exists(${self._partitionKey})`
+                ConditionExpression: 'attribute_not_exists(#PK)',
+                ExpressionAttributeNames: {
+                    '#PK': self._partitionKey
+                }
             };
             if (self._trustLocalTime)
             {
@@ -255,7 +261,10 @@ FailOpen.prototype.acquireLock = function(id, callback)
                     owner: dataBag.owner,
                     guid: dataBag.guid
                 },
-                ConditionExpression: `attribute_not_exists(${self._partitionKey}) or (guid = :guid and fencingToken = :fencingToken)`,
+                ConditionExpression: 'attribute_not_exists(#PK) or (guid = :guid and fencingToken = :fencingToken)',
+                ExpressionAttributeNames: {
+                    '#PK': self._partitionKey
+                },
                 ExpressionAttributeValues:
                 {
                     ":fencingToken": dataBag.lock.fencingToken,
@@ -349,7 +358,10 @@ const Lock = function(config)
                     owner: self._owner,
                     guid: newGuid
                 },
-                ConditionExpression: `attribute_exists(${self._partitionKey}) and guid = :guid`,
+                ConditionExpression: 'attribute_exists(#PK) and guid = :guid',
+                ExpressionAttributeNames: {
+                    '#PK': self._partitionKey
+                },
                 ExpressionAttributeValues:
                 {
                     ":guid": self._guid
@@ -402,7 +414,10 @@ Lock.prototype._releaseFailClosed = function(callback)
     {
         TableName: self._lockTable,
         Key: {},
-        ConditionExpression: `attribute_exists(${self._partitionKey}) and guid = :guid`,
+        ConditionExpression: `attribute_exists(#PK) and guid = :guid`,
+        ExpressionAttributeNames: {
+            '#PK': self._partitionKey
+        },
         ExpressionAttributeValues:
         {
             ":guid": self._guid
@@ -436,7 +451,10 @@ Lock.prototype._releaseFailOpen = function(callback)
             owner: self._owner,
             guid: self._guid
         },
-        ConditionExpression: `attribute_exists(${self._partitionKey}) and guid = :guid`,
+        ConditionExpression: 'attribute_exists(#PK) and guid = :guid',
+        ExpressionAttributeNames: {
+            '#PK': self._partitionKey
+        },
         ExpressionAttributeValues:
         {
             ":guid": self._guid


### PR DESCRIPTION
e.g. if partitionKey is `key` all the commands with `ConditionExpression` currently fail.

Thanks for this great module!


