### PR TITLE
Upgrade deprecated dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "aws-sdk": "2.506.0"
   },
   "dependencies": {
-    "joi": "14.3.1"
+    "@hapi/joi": "^15.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I noticed that `joi` was moved to `@hapi/joi`, so I updated it.