### PR TITLE
Feature/range key support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .git
 node_modules
 package-lock.json
+.idea

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "assert-latest-node": "(node -v | grep -q ${npm_package_scriptvars_latest_node}) || (echo \"Expected node version ${npm_package_scriptvars_latest_node}, got $(node -v)\" && exit 1)",
     "inject-examples": "node scripts/injectExamples.js",
     "prepublishOnly": "npm run inject-examples",
-    "readme": "node examples/readme.js"
+    "readme": "node examples/readme.js",
+    "mocha": "mocha './tests/**/test*.js' --exit --timeout 10000",
+    "test": "npm run mocha"
   },
   "scriptvars": {
     "latest_node": "v12.8.0"
@@ -35,5 +37,12 @@
     "Tom Yam",
     "Cooper Bell <john.cooper.bell@gmail.com>"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "chai-subset": "^1.6.0",
+    "dynamodb-local": "0.0.31",
+    "mocha": "^7.0.1",
+    "sinon": "^9.0.0"
+  }
 }

--- a/schema/failOpenConfig.js
+++ b/schema/failOpenConfig.js
@@ -14,6 +14,7 @@ const schema = Joi.object().keys(
         ).unknown().required(),
         lockTable: Joi.string().required(),
         partitionKey: Joi.string().invalid("fencingToken", "leaseDurationMs", "owner", "guid").required(),
+        rangeKey: Joi.string().invalid("owner", "guid"),
         heartbeatPeriodMs: Joi.number().integer().min(0),
         leaseDurationMs: Joi.number().integer().min(0).required(),
         trustLocalTime: Joi.boolean(),

--- a/tests/testFailOpenConfig.js
+++ b/tests/testFailOpenConfig.js
@@ -12,15 +12,15 @@ const spy = sinon.spy;
 
 chai.use(chaiSubset);
 
-describe("FailOpen lock", () => {
+const PORT = 8001;
+const TABLE_NAME = "my-lock-table-name";
+const PARTITION_KEY = "myPartitionKey";
+const HEARTBEAT_PERIOD_MS = 3e3;
+const LEASE_DURATION_MS = 1e4;
+const OWNER = 'me';
+const LOCK_ID = 'lockId';
 
-    const PORT = 8000;
-    const LOCK_TABLE = "my-lock-table-name";
-    const PARTITION_KEY = "mylocks";
-    const HEARTBEAT_PERIOD_MS = 3e3;
-    const LEASE_DURATION_MS = 1e4;
-    const OWNER = 'me';
-    const LOCK_ID = 'my_lock';
+describe("FailOpen lock with partitionKey only", () => {
 
     let dynamodb;
     let docClient;
@@ -35,7 +35,7 @@ describe("FailOpen lock", () => {
 
     const setup = () => {
         const params = {
-            TableName: LOCK_TABLE,
+            TableName: TABLE_NAME,
             KeySchema: [
                 {AttributeName: PARTITION_KEY, KeyType: "HASH"}
             ],
@@ -57,7 +57,7 @@ describe("FailOpen lock", () => {
 
     const drop = () => {
         return new Promise((resolve, reject) => {
-            dynamodb.deleteTable({TableName: LOCK_TABLE}).promise()
+            dynamodb.deleteTable({TableName: TABLE_NAME}).promise()
                 .then(dropped => resolve(dropped.TableDescription))
                 .catch(err => reject(err));
         });
@@ -85,7 +85,7 @@ describe("FailOpen lock", () => {
                 failOpenClient = new DynamoDBLockClient.FailOpen(
                     {
                         dynamodb: docClient,
-                        lockTable: LOCK_TABLE,
+                        lockTable: TABLE_NAME,
                         partitionKey: PARTITION_KEY,
                         heartbeatPeriodMs: HEARTBEAT_PERIOD_MS,
                         leaseDurationMs: LEASE_DURATION_MS,
@@ -131,7 +131,7 @@ describe("FailOpen lock", () => {
             // check for communication
             expect(getSpy.callCount).to.eq(1, 'get called: check for existing lock');
             expect(getSpy.lastCall.args[0]).to.eql({
-                "TableName": LOCK_TABLE,
+                "TableName": TABLE_NAME,
                 "Key": {
                     [PARTITION_KEY]: LOCK_ID
                 },
@@ -140,7 +140,7 @@ describe("FailOpen lock", () => {
 
             expect(putSpy.callCount).to.eq(1, 'put called: acquire new lock');
             expect(putSpy.lastCall.args[0]).to.containSubset({
-                "TableName": LOCK_TABLE,
+                "TableName": TABLE_NAME,
                 "Item": {
                     "fencingToken": 1,
                     "leaseDurationMs": LEASE_DURATION_MS,
@@ -149,7 +149,7 @@ describe("FailOpen lock", () => {
                 },
                 "ConditionExpression": "attribute_not_exists(#partitionKey)",
                 "ExpressionAttributeNames": {
-                    "#partitionKey": "mylocks"
+                    "#partitionKey": PARTITION_KEY
                 }
             });
 
@@ -190,7 +190,7 @@ describe("FailOpen lock", () => {
             expect(putSpy.callCount).to.eq(1, 'put called: check for existing lock');
             const guid = putSpy.lastCall.args[0].Item.guid;
             expect(putSpy.lastCall.args[0]).to.containSubset({
-                "TableName": LOCK_TABLE,
+                "TableName": TABLE_NAME,
                 "Item": {
                     "fencingToken": 1,
                     "leaseDurationMs": 1,
@@ -209,5 +209,207 @@ describe("FailOpen lock", () => {
             expect(deleteSpy.callCount).to.eq(0, 'delete called: no calls');
         }).catch(err => assert.fail(err));
     });
+});
 
+describe("FailOpen lock with partitionKey + rangeKey", () => {
+
+    const RANGE_KEY = "myRangeKey";
+    const SUB_LOCK_ID = 'subLockId';
+
+    let dynamodb;
+    let docClient;
+    let failOpenClient;
+    let putSpy, getSpy, deleteSpy;
+
+    const resetAllSpies = () => {
+        putSpy.resetHistory();
+        getSpy.resetHistory();
+        deleteSpy.resetHistory();
+    };
+
+    const setup = () => {
+        const params = {
+            TableName: TABLE_NAME,
+            KeySchema: [
+                {AttributeName: PARTITION_KEY, KeyType: "HASH"},
+                {AttributeName: RANGE_KEY, KeyType: "RANGE"},
+            ],
+            AttributeDefinitions: [
+                {AttributeName: PARTITION_KEY, AttributeType: "S"},
+                {AttributeName: RANGE_KEY, AttributeType: "S"}
+            ],
+            ProvisionedThroughput: {
+                ReadCapacityUnits: 10,
+                WriteCapacityUnits: 10
+            }
+        };
+
+        return new Promise((resolve, reject) => {
+            dynamodb.createTable(params).promise()
+                .then(created => resolve(created.TableDescription))
+                .catch(err => reject(err));
+        });
+    };
+
+    const drop = () => {
+        return new Promise((resolve, reject) => {
+            dynamodb.deleteTable({TableName: TABLE_NAME}).promise()
+                .then(dropped => resolve(dropped.TableDescription))
+                .catch(err => reject(err));
+        });
+    };
+
+    before(() => {
+        return DynamoDBEmbedded.launch(PORT, null, [], true, true)
+            .then(() => {
+                const config = {
+                    region: "aws-region-1", endpoint: `http://localhost:${PORT}`,
+                    accessKeyId: "whatever", secretAccessKey: "whatever"
+                };
+                dynamodb = new AWS.DynamoDB(config);
+                docClient = new AWS.DynamoDB.DocumentClient(config);
+            });
+    });
+
+    after(() => {
+        return DynamoDBEmbedded.stop(PORT);
+    });
+
+    beforeEach(() => {
+        return setup()
+            .then(() => {
+                failOpenClient = new DynamoDBLockClient.FailOpen(
+                    {
+                        dynamodb: docClient,
+                        lockTable: TABLE_NAME,
+                        partitionKey: PARTITION_KEY,
+                        rangeKey: RANGE_KEY,
+                        heartbeatPeriodMs: HEARTBEAT_PERIOD_MS,
+                        leaseDurationMs: LEASE_DURATION_MS,
+                        owner: OWNER
+                    }
+                );
+            });
+    });
+
+    beforeEach(() => {
+        putSpy = spy(docClient, 'put');
+        getSpy = spy(docClient, 'get');
+        deleteSpy = spy(docClient, 'delete');
+    });
+
+    afterEach(() => {
+        putSpy.restore();
+        getSpy.restore();
+        deleteSpy.restore();
+    });
+
+    afterEach(() => {
+        return drop();
+    });
+
+    it("acquires lock if there is no lock yet", () => {
+
+        return new Promise((resolve, reject) => {
+            failOpenClient.acquireLock([LOCK_ID, SUB_LOCK_ID], (error, lock) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    console.log(`acquired open lock with fencing token ${lock.fencingToken}`);
+                    lock.on('error', () => console.error('failed to heartbeat!'));
+                    resolve(lock);
+                }
+            });
+        }).then(lock => {
+            expect(lock._id).to.eq(LOCK_ID);
+            expect(lock._subId).to.eq(SUB_LOCK_ID);
+            expect(lock._leaseDurationMs).to.eq(LEASE_DURATION_MS);
+            expect(lock._heartbeatPeriodMs).to.eq(HEARTBEAT_PERIOD_MS);
+
+            // check for communication
+            expect(getSpy.callCount).to.eq(1, 'get called: check for existing lock');
+            expect(getSpy.lastCall.args[0]).to.eql({
+                "TableName": TABLE_NAME,
+                "Key": {
+                    [PARTITION_KEY]: LOCK_ID,
+                    [RANGE_KEY]: SUB_LOCK_ID
+                },
+                "ConsistentRead": true
+            });
+
+            expect(putSpy.callCount).to.eq(1, 'put called: acquire new lock');
+            expect(putSpy.lastCall.args[0]).to.containSubset({
+                "TableName": TABLE_NAME,
+                "Item": {
+                    "fencingToken": 1,
+                    "leaseDurationMs": LEASE_DURATION_MS,
+                    "owner": OWNER,
+                    [PARTITION_KEY]: LOCK_ID,
+                    [RANGE_KEY]: SUB_LOCK_ID
+                },
+                "ConditionExpression": "(attribute_not_exists(#partitionKey) and attribute_not_exists(#rangeKey))",
+                "ExpressionAttributeNames": {
+                    "#partitionKey": PARTITION_KEY,
+                    "#rangeKey": RANGE_KEY
+                }
+            });
+
+            expect(deleteSpy.callCount).to.eq(0, 'no delete called');
+
+        }).catch(err => assert.fail(err));
+    });
+
+    it('releases the lock if there is a lock present', async () => {
+
+        return new Promise((resolve, reject) => {
+            failOpenClient.acquireLock([LOCK_ID, SUB_LOCK_ID], (error, lock) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    console.log(`acquired open lock with fencing token ${lock.fencingToken}`);
+                    lock.on('error', () => console.error('failed to heartbeat!'));
+                    resolve(lock);
+                }
+            });
+        }).then(lock => {
+            resetAllSpies();
+            expect(lock._heartbeatTimeout).to.be.ok;
+            return new Promise((resolve, reject) => {
+                lock.release(err => {
+                    if (err) {
+                        reject(err)
+                    } else {
+                        expect(lock._heartbeatTimeout).to.be.undefined;
+                        resolve();
+                    }
+                });
+            });
+        }).then(lock => {
+            expect(lock).to.be.undefined;
+
+            expect(getSpy.callCount).to.eq(0, 'get called: no calls');
+            expect(putSpy.callCount).to.eq(1, 'put called: check for existing lock');
+            const guid = putSpy.lastCall.args[0].Item.guid;
+            expect(putSpy.lastCall.args[0]).to.containSubset({
+                "TableName": TABLE_NAME,
+                "Item": {
+                    "fencingToken": 1,
+                    "leaseDurationMs": 1,
+                    "owner": "me",
+                    "guid": guid,
+                    [PARTITION_KEY]: LOCK_ID,
+                    [RANGE_KEY]: SUB_LOCK_ID
+                },
+                "ConditionExpression": "(attribute_exists(#partitionKey) and attribute_exists(#rangeKey)) and guid = :guid",
+                "ExpressionAttributeNames": {
+                    "#partitionKey": PARTITION_KEY,
+                    "#rangeKey": RANGE_KEY
+                },
+                "ExpressionAttributeValues": {
+                    ":guid": guid
+                }
+            });
+            expect(deleteSpy.callCount).to.eq(0, 'delete called: no calls');
+        }).catch(err => assert.fail(err));
+    });
 });

--- a/tests/testFailOpenConfig.js
+++ b/tests/testFailOpenConfig.js
@@ -1,0 +1,213 @@
+"use strict";
+
+const AWS = require("aws-sdk");
+const assert = require("assert");
+const chai = require("chai");
+const chaiSubset = require("chai-subset");
+const sinon = require("sinon");
+const DynamoDBEmbedded = require("dynamodb-local");
+const DynamoDBLockClient = require("../index.js");
+const expect = chai.expect;
+const spy = sinon.spy;
+
+chai.use(chaiSubset);
+
+describe("FailOpen lock", () => {
+
+    const PORT = 8000;
+    const LOCK_TABLE = "my-lock-table-name";
+    const PARTITION_KEY = "mylocks";
+    const HEARTBEAT_PERIOD_MS = 3e3;
+    const LEASE_DURATION_MS = 1e4;
+    const OWNER = 'me';
+    const LOCK_ID = 'my_lock';
+
+    let dynamodb;
+    let docClient;
+    let failOpenClient;
+    let putSpy, getSpy, deleteSpy;
+
+    const resetAllSpies = () => {
+        putSpy.resetHistory();
+        getSpy.resetHistory();
+        deleteSpy.resetHistory();
+    };
+
+    const setup = () => {
+        const params = {
+            TableName: LOCK_TABLE,
+            KeySchema: [
+                {AttributeName: PARTITION_KEY, KeyType: "HASH"}
+            ],
+            AttributeDefinitions: [
+                {AttributeName: PARTITION_KEY, AttributeType: "S"}
+            ],
+            ProvisionedThroughput: {
+                ReadCapacityUnits: 10,
+                WriteCapacityUnits: 10
+            }
+        };
+
+        return new Promise((resolve, reject) => {
+            dynamodb.createTable(params).promise()
+                .then(created => resolve(created.TableDescription))
+                .catch(err => reject(err));
+        });
+    };
+
+    const drop = () => {
+        return new Promise((resolve, reject) => {
+            dynamodb.deleteTable({TableName: LOCK_TABLE}).promise()
+                .then(dropped => resolve(dropped.TableDescription))
+                .catch(err => reject(err));
+        });
+    };
+
+    before(() => {
+        return DynamoDBEmbedded.launch(PORT, null, [], true, true)
+            .then(() => {
+                const config = {
+                    region: "aws-region-1", endpoint: `http://localhost:${PORT}`,
+                    accessKeyId: "whatever", secretAccessKey: "whatever"
+                };
+                dynamodb = new AWS.DynamoDB(config);
+                docClient = new AWS.DynamoDB.DocumentClient(config);
+            });
+    });
+
+    after(() => {
+        return DynamoDBEmbedded.stop(PORT);
+    });
+
+    beforeEach(() => {
+        return setup()
+            .then(() => {
+                failOpenClient = new DynamoDBLockClient.FailOpen(
+                    {
+                        dynamodb: docClient,
+                        lockTable: LOCK_TABLE,
+                        partitionKey: PARTITION_KEY,
+                        heartbeatPeriodMs: HEARTBEAT_PERIOD_MS,
+                        leaseDurationMs: LEASE_DURATION_MS,
+                        owner: OWNER
+                    }
+                );
+            });
+    });
+
+    beforeEach(() => {
+        putSpy = spy(docClient, 'put');
+        getSpy = spy(docClient, 'get');
+        deleteSpy = spy(docClient, 'delete');
+    });
+
+    afterEach(() => {
+        putSpy.restore();
+        getSpy.restore();
+        deleteSpy.restore();
+    });
+
+    afterEach(() => {
+        return drop();
+    });
+
+    it("acquires lock if there is no lock yet", () => {
+
+        return new Promise((resolve, reject) => {
+            failOpenClient.acquireLock(LOCK_ID, (error, lock) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    console.log(`acquired open lock with fencing token ${lock.fencingToken}`);
+                    lock.on('error', () => console.error('failed to heartbeat!'));
+                    resolve(lock);
+                }
+            });
+        }).then(lock => {
+            expect(lock._id).to.eq(LOCK_ID);
+            expect(lock._leaseDurationMs).to.eq(LEASE_DURATION_MS);
+            expect(lock._heartbeatPeriodMs).to.eq(HEARTBEAT_PERIOD_MS);
+
+            // check for communication
+            expect(getSpy.callCount).to.eq(1, 'get called: check for existing lock');
+            expect(getSpy.lastCall.args[0]).to.eql({
+                "TableName": LOCK_TABLE,
+                "Key": {
+                    [PARTITION_KEY]: LOCK_ID
+                },
+                "ConsistentRead": true
+            });
+
+            expect(putSpy.callCount).to.eq(1, 'put called: acquire new lock');
+            expect(putSpy.lastCall.args[0]).to.containSubset({
+                "TableName": LOCK_TABLE,
+                "Item": {
+                    "fencingToken": 1,
+                    "leaseDurationMs": LEASE_DURATION_MS,
+                    "owner": OWNER,
+                    [PARTITION_KEY]: LOCK_ID
+                },
+                "ConditionExpression": "attribute_not_exists(#partitionKey)",
+                "ExpressionAttributeNames": {
+                    "#partitionKey": "mylocks"
+                }
+            });
+
+            expect(deleteSpy.callCount).to.eq(0, 'no delete called');
+
+        }).catch(err => assert.fail(err));
+    });
+
+    it('releases the lock if there is a lock present', async () => {
+
+        return new Promise((resolve, reject) => {
+            failOpenClient.acquireLock(LOCK_ID, (error, lock) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    console.log(`acquired open lock with fencing token ${lock.fencingToken}`);
+                    lock.on('error', () => console.error('failed to heartbeat!'));
+                    resolve(lock);
+                }
+            });
+        }).then(lock => {
+            resetAllSpies();
+            expect(lock._heartbeatTimeout).to.be.ok;
+            return new Promise((resolve, reject) => {
+                lock.release(err => {
+                    if (err) {
+                        reject(err)
+                    } else {
+                        expect(lock._heartbeatTimeout).to.be.undefined;
+                        resolve();
+                    }
+                });
+            });
+        }).then(lock => {
+            expect(lock).to.be.undefined;
+
+            expect(getSpy.callCount).to.eq(0, 'get called: no calls');
+            expect(putSpy.callCount).to.eq(1, 'put called: check for existing lock');
+            const guid = putSpy.lastCall.args[0].Item.guid;
+            expect(putSpy.lastCall.args[0]).to.containSubset({
+                "TableName": LOCK_TABLE,
+                "Item": {
+                    "fencingToken": 1,
+                    "leaseDurationMs": 1,
+                    "owner": "me",
+                    "guid": guid,
+                    [PARTITION_KEY]: LOCK_ID
+                },
+                "ConditionExpression": "attribute_exists(#partitionKey) and guid = :guid",
+                "ExpressionAttributeNames": {
+                    "#partitionKey": PARTITION_KEY
+                },
+                "ExpressionAttributeValues": {
+                    ":guid": guid
+                }
+            });
+            expect(deleteSpy.callCount).to.eq(0, 'delete called: no calls');
+        }).catch(err => assert.fail(err));
+    });
+
+});

--- a/tests/testFailOpenConfig.js
+++ b/tests/testFailOpenConfig.js
@@ -359,6 +359,23 @@ describe("FailOpen lock with partitionKey + rangeKey", () => {
         }).catch(err => assert.fail(err));
     });
 
+    it("cannot acquire lock for range_key = null", () => {
+
+        return new Promise((resolve, reject) => {
+            failOpenClient.acquireLock([LOCK_ID, null], (error, lock) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    console.log(`acquired open lock with fencing token ${lock.fencingToken}`);
+                    lock.on('error', () => console.error('failed to heartbeat!'));
+                    resolve(lock);
+                }
+            });
+        }).then(() => {
+            assert.fail('has to fail because range_key is null');
+        }).catch(err => expect(err.message).to.eq('The number of conditions on the keys is invalid'));
+    });
+
     it('releases the lock if there is a lock present', async () => {
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
This will add support for range keys as part of the lock. 

Use case:
The use case is to design an 1:n relationship between entities. Let's say you want to use the product identifier as the hash key. The mutation of the product serves as the range key.

| HASH_KEY (product)  | RANGE_KEY (product mutation)   |
|---|---|
|1   |A   |
|1   |B   |
|1   |C   |
|2   |D   |
|2   |E   |

Since for updating the product mutation a remote HTTP call needs to be performed, you will want to lock it for this period of time in order to avoid race conditions. Let's say the mutation update is related to the mutation 1-B. In this case both, 1-A and 1-C, don't need to be locked.

The PR includes:
* backwards compatible extension of the locking. The method signature `acquireLock` still accepts single lock ID as first and callback as second argument (regression tests were written prior to the changes). If range key needs to be passed then the first argument becomes an array with two elements:

Usage without range key:

```javascript
failOpenClient.acquireLock('myHashKey', (error, lock) => {
....
}
```

Usage with range key:

```javascript
failOpenClient.acquireLock(['myHashKey', 'myRangeKey'], (error, lock) => {
....
}
```


Missing points:
* tests for FailClosed locks
* better scenarios for concurrent lock trials
