### PR TITLE
 fix: race condition between heartbeat and releasing lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "main": "index.js",
   "devDependencies": {
+    "clone": "^2.1.2",
     "jest": "26.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
Releasing of a lock could fail (putItem would fail the condition) when
there was a heartbeat running at the same time.

When the 2 calls to dynamoDB happen synchronously, the GUID used by the heartbeat would be put into dynamodb, while the previous GUID would be used to release the lock. Releasing of the lock would therefore fail. I've only tested this for FailOpen locks, where there were longer waits because of this.
Perhaps with FailClosed locks the problem would be even worse.

The release of a lock now waits until the heartbeat is finished, using a Promise.

Since it relies on very specific timing it's hard to write a unit test for this.