### PR TITLE
fix: add sortKey to the FailedClosedConfig schema

### DIFF
--- a/schema/failClosedConfig.js
+++ b/schema/failClosedConfig.js
@@ -14,6 +14,7 @@ const schema = Joi.object().keys(
         ).unknown().required(),
         lockTable: Joi.string().required(),
         partitionKey: Joi.string().invalid("owner", "guid").required(),
+        sortKey: Joi.string().invalid("owner", "guid").required(),
         acquirePeriodMs: Joi.number().integer().min(0).required(),
         retryCount: Joi.number().integer().min(0)
     }


### PR DESCRIPTION
Hi @tristanls,

I noticed that the library would throw `Validation` error if we provided `sortKey` config to the `FailedClosedClient`. This PR helps the issue by fixing the schema definition.

Cheers
Andre